### PR TITLE
PD1_SE_PG-101 従業員情報に所属部署を管理できるようにする

### DIFF
--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -7,6 +7,7 @@ class DepartmentsController < ApplicationController
   # 部署詳細ページ
   def show
     @department = Department.find(params[:id])
+    @users = @department.users
   end
 
   # 部署新規作成ページ

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -1,0 +1,59 @@
+class DepartmentsController < ApplicationController
+  # 部署一覧ページ
+  def index
+    @departments = Department.all
+  end
+
+  # 部署詳細ページ
+  def show
+    @department = Department.find(params[:id])
+  end
+
+  # 部署新規作成ページ
+  def new
+    @department = Department.new
+  end
+
+  # 部署編集ページ
+  def edit
+    @department = Department.find(params[:id])
+  end
+
+  # 新規部署作成
+  def create
+    @department = Department.new(department_params)
+
+    if @department.save
+      redirect_to @department
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # 部署更新
+  def update
+    @department = Department.find(params[:id])
+
+    # 部署の更新処理を行う
+    if @department.update(department_params)
+      redirect_to @department
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # 部署削除
+  def destroy
+    @department = Department.find(params[:id])
+    @department.destroy
+
+    redirect_to departments_path, status: :see_other
+  end
+
+  private
+    def department_params
+      params
+        .require(:department)
+        .permit(:name)
+    end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  # 新規作成・編集時に部署情報をセット
+  before_action :set_departments, only: [:new, :edit]
+
   # ユーザー一覧ページ
   def index
     @users = User.all
@@ -67,5 +70,11 @@ class UsersController < ApplicationController
       params
         .require(:user)
         .permit(:full_name, :full_name_kana, :gender, :birth_date, :email, :home_phone, :mobile_phone, :postal_code, :prefecture, :city, :town, :address_block, :building, :department_id)
+    end
+
+    # 新規作成・編集時に部署情報をセット
+    def set_departments
+      # 部署情報を全て取得
+      @departments = Department.all
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,6 +66,6 @@ class UsersController < ApplicationController
       #【Rails API ActionController::Parameters】https://api.rubyonrails.org/v8.0/classes/ActionController/Parameters.html
       params
         .require(:user)
-        .permit(:full_name, :full_name_kana, :gender, :birth_date, :email, :home_phone, :mobile_phone, :postal_code, :prefecture, :city, :town, :address_block, :building)
+        .permit(:full_name, :full_name_kana, :gender, :birth_date, :email, :home_phone, :mobile_phone, :postal_code, :prefecture, :city, :town, :address_block, :building, :department_id)
     end
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,0 +1,2 @@
+class Department < ApplicationRecord
+end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -4,5 +4,6 @@ class Department < ApplicationRecord
 
     validates :name,
               presence: { message: "を入力してください" }, # nameは必須
-              length: { maximum: 50, message: "は50文字以内で入力してください" } # nameの最大文字数は50
+              length: { maximum: 50, message: "は50文字以内で入力してください" }, # nameの最大文字数は50
+              uniqueness: { message: "はすでに存在します" }
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,2 +1,4 @@
 class Department < ApplicationRecord
+    # 部署は複数のユーザーを持つ
+    has_many :users
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,4 +1,8 @@
 class Department < ApplicationRecord
     # 部署は複数のユーザーを持つ
     has_many :users
+
+    validates :name,
+              presence: { message: "を入力してください" }, # nameは必須
+              length: { maximum: 50, message: "は50文字以内で入力してください" } # nameの最大文字数は50
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+    # ユーザーは1つの部署に所属する
+    belongs_to :department
+
     # ユーザーの性別
     enum :gender, { male: 0, female: 1, other: 2 }
 

--- a/app/views/departments/_form.html.erb
+++ b/app/views/departments/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: @department do |form| %>
+  <div>
+    <%= form.label :name, "部署名" %>
+    <%= form.text_field :name %>
+    <% @department.errors.full_messages_for(:name).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= form.submit "保存" %>
+  </div>
+<% end %>

--- a/app/views/departments/edit.html.erb
+++ b/app/views/departments/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>部署の編集</h1>
+
+<%= render "form", department: @department %>

--- a/app/views/departments/index.html.erb
+++ b/app/views/departments/index.html.erb
@@ -1,0 +1,13 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>部署一覧</h1>
+
+<ul id="departments">
+  <% @departments.each do |department| %>
+    <li>
+      <%= link_to department.name, department %>
+    </li>
+  <% end %>
+</ul>
+
+<%= link_to "新しい部署を作成", new_department_path %>

--- a/app/views/departments/new.html.erb
+++ b/app/views/departments/new.html.erb
@@ -1,0 +1,3 @@
+<h1>新しい部署の作成しよう</h1>
+
+<%= render "form", department: @department %>

--- a/app/views/departments/show.html.erb
+++ b/app/views/departments/show.html.erb
@@ -5,7 +5,7 @@
 <section>
   <h2>所属ユーザー</h2>
   <ul>
-    <% @department.users.each do |user| %>
+    <% @users.each do |user| %>
       <li>
         <%= link_to user.full_name, user %>
       </li>

--- a/app/views/departments/show.html.erb
+++ b/app/views/departments/show.html.erb
@@ -1,0 +1,26 @@
+<p style="color: green"><%= notice %></p>
+
+<h1><%= @department.name %></h1>
+
+<section>
+  <h2>所属ユーザー</h2>
+  <ul>
+    <% @department.users.each do |user| %>
+      <li>
+        <%= link_to user.full_name, user %>
+      </li>
+    <% end %>
+  </ul>
+</section>
+
+<section>
+  <h2>操作</h2>
+  <ul>
+    <li><%= link_to "部署名の編集", edit_department_path(@department) %></li>
+    <li><%= link_to "部署を削除", department_path(@department), data: {
+      turbo_method: :delete,
+      turbo_confirm: "本当に削除しますか？"
+    } %></li>
+    <li><%= link_to "部署一覧に戻る", departments_path %></li>
+  </ul>
+</section>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -42,6 +42,15 @@
             <% end %>
         </div>
         <div>
+            <%= form.label :department_id, "部署" %>
+            <%= form.collection_select :department_id,
+                    Department.all, :id, :name,
+                    { prompt: "選択してください" } %>
+            <% @user.errors.full_messages_for(:department).each do |message| %>
+                <div><%= message %></div>
+            <% end %>
+        </div>
+        <div>
             <%= form.label :home_phone, "自宅電話" %>
             <%= form.telephone_field :home_phone %>
             <% @user.errors.full_messages_for(:home_phone).each do |message| %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -44,7 +44,7 @@
         <div>
             <%= form.label :department_id, "部署" %>
             <%= form.collection_select :department_id,
-                    Department.all, :id, :name,
+                    @departments, :id, :name,
                     { prompt: "選択してください" } %>
             <% @user.errors.full_messages_for(:department).each do |message| %>
                 <div><%= message %></div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,7 @@
             性別：<%= @user.gender.present? ? { male: "男", female: "女", other: "その他" }[@user.gender.to_sym] : "未登録" %>
         </li>
         <li>生年月日：<%= @user.birth_date&.strftime("%Y年%m月%d日") || "未登録" %></li>
-        <li>部署：<%= @user.department.name || "未登録" %></li>
+        <li>部署：<%= link_to @user.department.name, @user.department || "未登録" %></li>
     </ul>
 
     <h2>連絡先</h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,7 @@
             性別：<%= @user.gender.present? ? { male: "男", female: "女", other: "その他" }[@user.gender.to_sym] : "未登録" %>
         </li>
         <li>生年月日：<%= @user.birth_date&.strftime("%Y年%m月%d日") || "未登録" %></li>
+        <li>部署：<%= @user.department.name || "未登録" %></li>
     </ul>
 
     <h2>連絡先</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   # 【resources 参考文献】https://api.rubyonrails.org/v8.0/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resources
   resources :users
 
+  # 部署に関するルーティングを定義
+  resources :departments
+
   # resourcesの代わりに個別でルーティングを定義する場合
   # get 'users', to: 'users#index'
   # post 'users/create', to: 'users#create'

--- a/db/migrate/20250617072428_create_departments.rb
+++ b/db/migrate/20250617072428_create_departments.rb
@@ -1,0 +1,9 @@
+class CreateDepartments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :departments do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250617072604_add_department_ref_to_users.rb
+++ b/db/migrate/20250617072604_add_department_ref_to_users.rb
@@ -1,0 +1,6 @@
+class AddDepartmentRefToUsers < ActiveRecord::Migration[7.0]
+  def change
+    # ユーザーテーブルに部署の参照を追加
+    add_reference :users, :department, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_17_072428) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_17_072604) do
   create_table "departments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -33,6 +33,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_17_072428) do
     t.string "address_block"
     t.string "building"
     t.date "birth_date"
+    t.bigint "department_id"
+    t.index ["department_id"], name: "index_users_on_department_id"
   end
 
+  add_foreign_key "users", "departments"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_13_003129) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_17_072428) do
+  create_table "departments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "full_name"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# 部署のシードデータ
+departments = [
+  "コーポレート統括部",
+  "DX推進本部",
+  "情報システム部",
+  "プロダクト開発統括1部",
+  "プロダクト開発統括2部",
+  "プロダクト企画統括部",
+  "IoT統括部",
+  "データマネジメント部",
+  "デジタルマーケティング部",
+  "企画室"
+]
+
+departments.each do |department_name|
+  Department.create(name: department_name)
+end

--- a/test/controllers/departments_controller_test.rb
+++ b/test/controllers/departments_controller_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class DepartmentsControllerTest < ActionDispatch::IntegrationTest
+  test "部署一覧ページの表示" do
+    # 部署一覧ページにGETリクエストを送信
+    get departments_url
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+  end
+
+  test "部署の作成" do
+    # POSTリクエスト送信後に部署が作成されたかどうかを確認する
+    assert_difference("Department.count") do
+      post departments_url, params: { department: { name: "test_department" } }
+    end
+
+    # レスポンスがリダイレクトであることを確認
+    assert_response :redirect
+  end
+
+  test "無効なパラメータで部署が作成できないこと" do
+    # POSTリクエスト送信後に部署が作成されないことを確認する
+    assert_no_difference("Department.count") do
+      post departments_url, params: { department: { name: "" } }
+    end
+
+    # レスポンスが422番であることを確認
+    assert_response :unprocessable_entity
+  end
+
+  test "部署新規作成ページの表示" do
+    # 部署新規作成ページにGETリクエストを送信
+    get new_department_url
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+  end
+
+  test "ユーザー編集ページの表示" do
+    # departmentsメソッドを使用して、テスト用の部署を取得
+    department = departments(:test_department)
+
+    # 作成した部署の編集ページにGETリクエストを送信
+    get edit_department_url(department)
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+  end
+
+  test "部署詳細ページの表示" do
+    # departmentsメソッドを使用して、テスト用の部署を取得
+    department = departments(:test_department)
+
+    # 作成した部署の詳細ページにGETリクエストを送信
+    get department_url(department)
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+  end
+
+    test "部署情報の更新" do
+    # departmentsメソッドを使用して、テスト用の部署を取得
+    department = departments(:test_department)
+
+    # PATCHリクエストを送信して部署情報を更新
+    # assert_no_differenceメソッドを使用して、Departmentモデルのレコード数が変わらないことを確認
+    assert_no_difference("Department.count") do
+      patch department_url(department), params: { department: { name: "updated_department" } }
+    end
+
+    # レスポンスがリダイレクトであることを確認
+    assert_response :redirect
+
+    # 更新後のユーザー情報を取得
+    department.reload
+    # ユーザー名が更新されていることを確認
+    assert_equal "updated_department", department.name
+  end
+
+  test "無効なパラメータで部署を更新できないこと" do
+    # departmentsメソッドを使用して、テスト用の部署を取得
+    department = departments(:test_department)
+
+    # PATCHリクエストを送信して部署情報を更新
+    # assert_no_differenceメソッドを使用して、Departmentモデルのレコード数が変わらないことを確認
+    assert_no_difference("Department.count") do
+      patch department_url(department), params: { department: { name: "" } }
+    end
+
+    # レスポンスが422番であることを確認
+    assert_response :unprocessable_entity
+
+    # 更新後のユーザー情報を取得
+    department.reload
+    # 部署名が更新されていないことを確認
+    assert_equal "test_department", department.name
+  end
+
+  test "部署の削除" do
+    # departmentsメソッドを使用して、テスト用の部署を取得
+    department = departments(:test_department)
+
+    # DELETEリクエストを送信して部署を削除
+    # assert_differenceメソッドを使用して、Departmentモデルのレコード数が1減ることを確認
+    assert_difference("Department.count", -1) do
+      delete department_url(department)
+    end
+
+    # レスポンスがリダイレクトであることを確認
+    assert_response :see_other
+  end
+end

--- a/test/controllers/departments_controller_test.rb
+++ b/test/controllers/departments_controller_test.rb
@@ -12,7 +12,7 @@ class DepartmentsControllerTest < ActionDispatch::IntegrationTest
   test "部署の作成" do
     # POSTリクエスト送信後に部署が作成されたかどうかを確認する
     assert_difference("Department.count") do
-      post departments_url, params: { department: { name: "test_department" } }
+      post departments_url, params: { department: { name: "add_department" } }
     end
 
     # レスポンスがリダイレクトであることを確認

--- a/test/fixtures/departments.yml
+++ b/test/fixtures/departments.yml
@@ -1,0 +1,4 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+test_department:
+  name: "test_department"


### PR DESCRIPTION
## イシュー番号
- open #11 

## 関連ドキュメント
[Railsガイド Active Record の関連付け](https://railsguides.jp/v7.0/association_basics.html)

## 実装内容
- 部署マスターテーブルを作成
- ユーザーテーブルに部署IDを保存するカラムを追加して部署テーブルとリレーションを設定
- ユーザー作成・更新フォームに部署フィールドを追加
- ユーザー詳細画面に部署を表示

## テスト実行結果
![image](https://github.com/user-attachments/assets/53c937e4-1f5c-4596-bfe3-2ece6c4bbe0a)

## 特にレビューして欲しい部分
リレーションの設定に問題がないかどうか