### PR TITLE
PD1_SE_PG-121 プロフィール画像を登録できるようにする。

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,8 +48,21 @@ class Admin::UsersController < Admin::ApplicationController
     @departments = Department.all
     @skills = Skill.all
 
+    # imageフィールドに新しい画像があるかチェック
+    if params[:user][:image].present?
+      upload = params[:user][:image]
+
+      # ファイルの
+      upload_file = UploadFile.create_and_store(upload)
+
+      # 古いアップロードファイルを削除する
+      @user.upload_file&.destroy
+      @user.upload_file = upload_file
+    end
+
     # ユーザーの更新処理を行う
-    if @user.update(user_params)
+    # ユーザーテーブルには`image`フィールドがないため更新前に削除する。
+    if @user.update(user_params.except(:image))
       # ユーザー詳細ページにリダイレクト
       redirect_to admin_user_url(@user)
     else
@@ -79,7 +92,7 @@ class Admin::UsersController < Admin::ApplicationController
           :full_name, :full_name_kana, :gender, :birth_date,
           :email, :home_phone, :mobile_phone, :postal_code,
           :prefecture, :city, :town, :address_block, :building,
-          :department_id, skill_ids: []
+          :department_id, :image, skill_ids: []
         )
     end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,15 @@
+class ImagesController < ActionController::Base
+  def show
+    # keyパラメータによってファイルを取得し、存在しない場合は404エラーを返す。
+    file = UploadFile.find_by!(key: params[:key])
+
+    # ファイルを送信する
+    # ブラウザで保存する際のファイル名をDBに保存されているファイル名に指定
+    # ファイルはインライン表示に指定。`attachment`にするとダウンロードされるようになる。
+    # MIMEタイプを指定
+    send_file file.storage_path,
+              filename:    file.filename,
+              disposition: :inline,
+              type:        file.content_type
+  end
+end

--- a/app/models/upload_file.rb
+++ b/app/models/upload_file.rb
@@ -1,0 +1,34 @@
+class UploadFile < ApplicationRecord
+  # ユーザーに対して画像は一枚のみ設定できるようにする
+  has_one :user
+
+  # アップロードする画像のタイプを`image/jpeg`と`image/png`のみに指定
+  validates :content_type, inclusion: { in: ["image/jpeg", "image/png"] }
+
+  # 画像のファイルサイズを2MG以下に設定
+  validates :byte_size, numericality: { less_than_or_equal_to: 2.megabytes }
+
+  def self.create_and_store(upload)
+    # アップロードされたデータからレコードを作成
+    # upload => ActionDispatch::Http::UploadedFile
+    record = create(
+      key: SecureRandom.hex(16),
+      filename: upload.original_filename,
+      content_type: upload.content_type,
+      byte_size: upload.size
+    )
+
+    # キーを参考にしてディレクトリを作成する
+    FileUtils.mkdir_p(File.dirname(record.storage_path))
+
+    # アップロードされたファイルをFIleオブジェクトに変換して、key元に作成したディレクトリにファイルをコピーする
+    IO.copy_stream(upload.tempfile, record.storage_path)
+
+    # upload_fileのレコードを返す
+    record
+  end
+
+  def storage_path
+    Rails.root.join("storage", "uploads", key[0..1], key[2..3], key)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
     # ユーザーは1つの部署に所属する
     belongs_to :department
 
+    # ユーザーは1つの画像を所持または未所持
+    belongs_to :upload_file
+
     # ユーザーはUserSkillsモデルを経由して複数のスキルを所有する
     has_many :user_skills
     has_many :skills, through: :user_skills

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -35,6 +35,13 @@
             <% end %>
         </div>
         <div>
+            <%= form.label :image, "画像" %>
+            <%= form.file_field :image %>
+            <% @user.errors.full_messages_for(:image).each do |message| %>
+                <div><%= message %></div>
+            <% end %>
+        </div>
+        <div>
             <%= form.label :email, "メールアドレス" %>
             <%= form.email_field :email %>
             <% @user.errors.full_messages_for(:email).each do |message| %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,6 +9,7 @@
             性別：<%= @user.gender.present? ? { male: "男", female: "女", other: "その他" }[@user.gender.to_sym] : "未登録" %>
         </li>
         <li>生年月日：<%= @user.birth_date&.strftime("%Y年%m月%d日") || "未登録" %></li>
+        <li>画像：<%= @user.upload_file ? image_tag(image_url(@user.upload_file.key)) : "画像が登録されていません" %></li>
         <li>部署：<%= link_to @user.department.name, admin_department_path(@user.department) || "未登録" %></li>
     </ul>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,7 @@
             性別：<%= @user.gender.present? ? { male: "男", female: "女", other: "その他" }[@user.gender.to_sym] : "未登録" %>
         </li>
         <li>生年月日：<%= @user.birth_date&.strftime("%Y年%m月%d日") || "未登録" %></li>
+        <li>画像：<%= @user.upload_file ? image_tag(image_url(@user.upload_file.key)) : "画像が登録されていません" %></li>
         <li>部署：<%= @user.department.name || "未登録" %></li>
     </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :show]
 
+  # 画像表示用のルーティングを定義
+  get "/images/:key", to: "images#show", as: "image"
+
   namespace :admin do
     # ユーザーに関するルーティングを定義
     # 【resources 参考文献】https://api.rubyonrails.org/v8.0/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resources

--- a/db/migrate/20250630045009_create_upload_files.rb
+++ b/db/migrate/20250630045009_create_upload_files.rb
@@ -1,0 +1,14 @@
+class CreateUploadFiles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :upload_files do |t|
+      t.string :key, null: false
+      t.string :filename, null: false
+      t.string :content_type, null: false
+      t.bigint :byte_size, null: false
+
+      t.timestamps
+    end
+
+    add_index :upload_files, :key, unique: true
+  end
+end

--- a/db/migrate/20250630052837_add_upload_file_id_to_users.rb
+++ b/db/migrate/20250630052837_add_upload_file_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddUploadFileIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :upload_file, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_20_071927) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_30_052837) do
   create_table "departments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -21,6 +21,16 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_20_071927) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "upload_files", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type", null: false
+    t.bigint "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_upload_files_on_key", unique: true
   end
 
   create_table "user_skills", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -49,10 +59,13 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_20_071927) do
     t.string "building"
     t.date "birth_date"
     t.bigint "department_id"
+    t.bigint "upload_file_id"
     t.index ["department_id"], name: "index_users_on_department_id"
+    t.index ["upload_file_id"], name: "index_users_on_upload_file_id"
   end
 
   add_foreign_key "user_skills", "skills"
   add_foreign_key "user_skills", "users"
   add_foreign_key "users", "departments"
+  add_foreign_key "users", "upload_files"
 end


### PR DESCRIPTION
## イシュー番号
- open #19

## 関連ドキュメント
[Ruby モジュール FileUtils](https://docs.ruby-lang.org/ja/latest/class/FileUtils.html#M_MAKEDIRS)
[Ruby モジュール SecureRandom](https://docs.ruby-lang.org/ja/latest/class/SecureRandom.html#S_HEX)
[Ruby クラス IO](https://docs.ruby-lang.org/ja/latest/class/IO.html#S_COPY_STREAM)

## 実装内容
- ユーザー編集画面から画像を登録できるようにする
- ユーザー詳細画面で画像を表示できるようにする
- 保存した画像ファイルは`storage`ディレクトリに保存する

## 確認したこと

## 特にレビューして欲しい部分
- コントローラの画像表示用のshowアクション
- UploadFileモデル