### PR TITLE
PD1_SE_PG-124 従業員一覧ページで検索・絞り込みをできるようにした

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,28 +4,17 @@ class Admin::UsersController < Admin::ApplicationController
     @users = User.all
     @prefectures = User.prefectures
 
-    # 名前検索がある場合
-    unless params[:name].blank?
-      @users = @users.search_by_full_name(params[:name])
-    end
+    # 検索フォームから検索条件のクエリパラメータを取得し、検索を行っていく処理
+    @users = @users.search_by_full_name(params[:name]) if params[:name].present?
 
-    # 都道府県検索がある場合
-    unless params[:pref].blank?
-      @users = @users.search_by_prefecture(params[:pref])
-    end
+    @users = @users.search_by_prefecture(params[:pref]) if @prefectures.value?(params[:pref])
 
-    # 誕生日検索がある場合
-    unless params[:birth].blank?
-      @users = @users.order_by_birth_date(params[:birth])
-    end
+    @users = @users.order_by_birth_date(params[:birth]) if ["asc", "desc"].include?(params[:birth])
 
+    # kaminariのページネーションを追加して、表示件数の制御を行う
     @users = @users.order(:full_name).page(params[:page])
 
-    # 表示件数の指定がある場合
-    unless params[:per].blank?
-      @users = @users.per(params[:per])
-    end
-
+    @users = @users.per(params[:per]) if ["10", "50", "100"].include?(params[:per])
   end
 
   # ユーザー詳細ページ

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,17 +4,23 @@ class Admin::UsersController < Admin::ApplicationController
     @users = User.all
     @prefectures = User.prefectures
 
+    # veiwテンプレートで使用するためインスタンス変数で定義
+    @param_name = params[:name]
+    @param_pref = params[:pref]
+    @param_birth = params[:birth]
+    @param_per = params[:per]
+
     # 検索フォームから検索条件のクエリパラメータを取得し、検索を行っていく処理
-    @users = @users.search_by_full_name(params[:name]) if params[:name].present?
+    @users = @users.search_by_full_name(@param_name) if @param_name.present?
 
-    @users = @users.search_by_prefecture(params[:pref]) if @prefectures.value?(params[:pref])
+    @users = @users.search_by_prefecture(@param_pref) if @prefectures.value?(@param_pref)
 
-    @users = @users.order_by_birth_date(params[:birth]) if ["asc", "desc"].include?(params[:birth])
+    @users = @users.order_by_birth_date(@param_birth) if ["asc", "desc"].include?(@param_birth)
 
     # kaminariのページネーションを追加して、表示件数の制御を行う
     @users = @users.order(:full_name).page(params[:page])
 
-    @users = @users.per(params[:per]) if ["10", "50", "100"].include?(params[:per])
+    @users = @users.per(@param_per) if ["10", "50", "100"].include?(@param_per)
   end
 
   # ユーザー詳細ページ

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,31 @@
 class Admin::UsersController < Admin::ApplicationController
   # ユーザー一覧ページ
   def index
-    @users = User.order(:full_name).page params[:page]
+    @users = User.all
+    @prefectures = User.prefectures
+
+    # 名前検索がある場合
+    unless params[:name].blank?
+      @users = @users.search_by_full_name(params[:name])
+    end
+
+    # 都道府県検索がある場合
+    unless params[:pref].blank?
+      @users = @users.search_by_prefecture(params[:pref])
+    end
+
+    # 誕生日検索がある場合
+    unless params[:birth].blank?
+      @users = @users.order_by_birth_date(params[:birth])
+    end
+
+    @users = @users.order(:full_name).page(params[:page])
+
+    # 表示件数の指定がある場合
+    unless params[:per].blank?
+      @users = @users.per(params[:per])
+    end
+
   end
 
   # ユーザー詳細ページ

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,20 @@
 class UsersController < ApplicationController
   # ユーザー一覧ページ
   def index
-    @users = User.order(:full_name).page params[:page]
+    @users = User.all
+    @prefectures = User.prefectures
+
+    # 検索フォームから検索条件のクエリパラメータを取得し、検索を行っていく処理
+    @users = @users.search_by_full_name(params[:name]) if params[:name].present?
+
+    @users = @users.search_by_prefecture(params[:pref]) if @prefectures.value?(params[:pref])
+
+    @users = @users.order_by_birth_date(params[:birth]) if ["asc", "desc"].include?(params[:birth])
+
+    # kaminariのページネーションを追加して、表示件数の制御を行う
+    @users = @users.order(:full_name).page(params[:page])
+
+    @users = @users.per(params[:per]) if ["10", "50", "100"].include?(params[:per])
   end
 
   # ユーザー詳細ページ

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,17 +4,23 @@ class UsersController < ApplicationController
     @users = User.all
     @prefectures = User.prefectures
 
+    # veiwテンプレートで使用するためインスタンス変数で定義
+    @param_name = params[:name]
+    @param_pref = params[:pref]
+    @param_birth = params[:birth]
+    @param_per = params[:per]
+
     # 検索フォームから検索条件のクエリパラメータを取得し、検索を行っていく処理
-    @users = @users.search_by_full_name(params[:name]) if params[:name].present?
+    @users = @users.search_by_full_name(@param_name) if @param_name.present?
 
-    @users = @users.search_by_prefecture(params[:pref]) if @prefectures.value?(params[:pref])
+    @users = @users.search_by_prefecture(@param_pref) if @prefectures.value?(@param_pref)
 
-    @users = @users.order_by_birth_date(params[:birth]) if ["asc", "desc"].include?(params[:birth])
+    @users = @users.order_by_birth_date(@param_birth) if ["asc", "desc"].include?(@param_birth)
 
     # kaminariのページネーションを追加して、表示件数の制御を行う
     @users = @users.order(:full_name).page(params[:page])
 
-    @users = @users.per(params[:per]) if ["10", "50", "100"].include?(params[:per])
+    @users = @users.per(@param_per) if ["10", "50", "100"].include?(@param_per)
   end
 
   # ユーザー詳細ページ

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,22 @@ class User < ApplicationRecord
     # ユーザーの性別
     enum :gender, { male: 0, female: 1, other: 2 }
 
+    # 都道府県のENUM
+    enum :prefecture, {
+      hokkaido: "北海道", aomori: "青森県", iwate: "岩手県", miyagi: "宮城県",
+      akita: "秋田県", yamagata: "山形県", fukushima: "福島県", ibaraki: "茨城県",
+      tochigi: "栃木県", gunma: "群馬県", saitama: "埼玉県", chiba: "千葉県",
+      tokyo: "東京都", kanagawa: "神奈川県", niigata: "新潟県", toyama: "富山県",
+      ishikawa: "石川県", fukui: "福井県", yamanashi: "山梨県", nagano: "長野県",
+      gifu: "岐阜県", shizuoka: "静岡県", aichi: "愛知県", mie: "三重県",
+      shiga: "滋賀県", kyoto: "京都府", osaka: "大阪府", hyogo: "兵庫県",
+      nara: "奈良県", wakayama: "和歌山県", tottori: "鳥取県", shimane: "島根県",
+      okayama: "岡山県", hiroshima: "広島県", yamaguchi: "山口県", tokushima:"徳島県",
+      kagawa: "香川県", ehime: "愛媛県", kochi: "高知県", fukuoka: "福岡県",
+      saga: "佐賀県", nagasaki: "長崎県", kumamoto: "熊本県", oita: "大分県",
+      miyazaki: "宮崎県", kagoshima: "鹿児島県", okinawa: "沖縄県"
+    }
+
     validates :full_name,
               presence: { message: "を入力してください" }, # full_nameは必須
               length: { maximum: 50 } # full_nameの最大文字数は50

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,20 @@ class User < ApplicationRecord
     # imageフィールドをバイナリデータに変換する
     after_validation :extract_image_binary
 
+    # ユーザー名で検索
+    def self.search_by_full_name(full_name)
+      where("full_name LIKE ?", "%#{full_name}%")
+    end
+
+    # 都道府県で検索
+    def self.search_by_prefecture(prefecture)
+      where("prefecture = ?", prefecture)
+    end
+
+    # 誕生日順でソート
+    def self.order_by_birth_date(dir)
+      order(birth_date: dir)
+    end
 
     private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,7 +86,7 @@ class User < ApplicationRecord
 
     # 検索用のクエリを発行するメソッドを作成する
     # scopeメソッドを使用してActiveRecord::Relationオブジェクトを返しクエリの構築を行う
-    scope :search_by_full_name, ->(full_name) { where("full_name LIKE ?", "%#{full_name}%") }
+    scope :search_by_full_name, ->(full_name) { where("full_name LIKE ?", "%" + full_name + "%") }
 
     scope :search_by_prefecture, ->(prefecture) { where("prefecture = ?", prefecture) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,20 +84,14 @@ class User < ApplicationRecord
     # imageフィールドをバイナリデータに変換する
     after_validation :extract_image_binary
 
-    # ユーザー名で検索
-    def self.search_by_full_name(full_name)
-      where("full_name LIKE ?", "%#{full_name}%")
-    end
+    # 検索用のクエリを発行するメソッドを作成する
+    # scopeメソッドを使用してActiveRecord::Relationオブジェクトを返しクエリの構築を行う
+    scope :search_by_full_name, ->(full_name) { where("full_name LIKE ?", "%#{full_name}%") }
 
-    # 都道府県で検索
-    def self.search_by_prefecture(prefecture)
-      where("prefecture = ?", prefecture)
-    end
+    scope :search_by_prefecture, ->(prefecture) { where("prefecture = ?", prefecture) }
 
-    # 誕生日順でソート
-    def self.order_by_birth_date(dir)
-      order(birth_date: dir)
-    end
+    # order_typeには`asc`または`desc`が入る
+    scope :order_by_birth_date, ->(order_type) { order(birth_date: order_type) }
 
     private
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,16 +2,16 @@
 
 <%= form_with url: "/admin/users", method: :get do |form| %>
   <%= form.label :name, "名前" %>
-  <%= form.text_field :name, value: params[:name] %>
+  <%= form.text_field :name, value: @param_name %>
 
   <%= form.label :pref, "都道府県" %>
-  <%= form.select :pref, options_for_select(@prefectures.values, params[:pref]), { include_blank: "指定なし" } %>
+  <%= form.select :pref, options_for_select(@prefectures.values, @param_pref), { include_blank: "指定なし" } %>
 
   <%= form.label :birth, "誕生日順" %>
-  <%= form.select :birth, options_for_select([["古い順（年齢が高い）", "asc"], ["新しい順（年齢が低い）", "desc"]], params[:birth]), { include_blank: "指定なし" } %>
+  <%= form.select :birth, options_for_select([["古い順（年齢が高い）", "asc"], ["新しい順（年齢が低い）", "desc"]], @param_birth), { include_blank: "指定なし" } %>
 
   <%= form.label :per, "表示件数" %>
-  <%= form.select :per, options_for_select([["10件", 10], ["50件", 50], ["100件", 100]], params[:per]), { include_blank: "指定なし" } %>
+  <%= form.select :per, options_for_select([["10件", 10], ["50件", 50], ["100件", 100]], @param_per), { include_blank: "指定なし" } %>
 
   <%= form.submit "検索" %>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,5 +1,21 @@
 <h1>ユーザー一覧</h1>
 
+<%= form_with url: "/admin/users", method: :get do |form| %>
+  <%= form.label :name, "名前" %>
+  <%= form.text_field :name, value: params[:name] %>
+
+  <%= form.label :pref, "都道府県" %>
+  <%= form.select :pref, options_for_select(@prefectures.values, params[:pref]), { include_blank: "指定なし" } %>
+
+  <%= form.label :birth, "誕生日順" %>
+  <%= form.select :birth, options_for_select([["古い順（年齢が高い）", "asc"], ["新しい順（年齢が低い）", "desc"]], params[:birth]), { include_blank: "指定なし" } %>
+
+  <%= form.label :per, "表示件数" %>
+  <%= form.select :per, options_for_select([["10件", 10], ["50件", 50], ["100件", 100]], params[:per]), { include_blank: "指定なし" } %>
+
+  <%= form.submit "検索" %>
+<% end %>
+
 <ul>
     <% @users.each do |user| %>
         <li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,21 @@
 <h1>ユーザー一覧</h1>
 
+<%= form_with url: "/users", method: :get do |form| %>
+  <%= form.label :name, "名前" %>
+  <%= form.text_field :name, value: params[:name] %>
+
+  <%= form.label :pref, "都道府県" %>
+  <%= form.select :pref, options_for_select(@prefectures.values, params[:pref]), { include_blank: "指定なし" } %>
+
+  <%= form.label :birth, "誕生日順" %>
+  <%= form.select :birth, options_for_select([["古い順（年齢が高い）", "asc"], ["新しい順（年齢が低い）", "desc"]], params[:birth]), { include_blank: "指定なし" } %>
+
+  <%= form.label :per, "表示件数" %>
+  <%= form.select :per, options_for_select([["10件", 10], ["50件", 50], ["100件", 100]], params[:per]), { include_blank: "指定なし" } %>
+
+  <%= form.submit "検索" %>
+<% end %>
+
 <ul>
     <% @users.each do |user| %>
         <li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,16 +2,16 @@
 
 <%= form_with url: "/users", method: :get do |form| %>
   <%= form.label :name, "名前" %>
-  <%= form.text_field :name, value: params[:name] %>
+  <%= form.text_field :name, value: @param_name %>
 
   <%= form.label :pref, "都道府県" %>
-  <%= form.select :pref, options_for_select(@prefectures.values, params[:pref]), { include_blank: "指定なし" } %>
+  <%= form.select :pref, options_for_select(@prefectures.values, @param_pref), { include_blank: "指定なし" } %>
 
   <%= form.label :birth, "誕生日順" %>
-  <%= form.select :birth, options_for_select([["古い順（年齢が高い）", "asc"], ["新しい順（年齢が低い）", "desc"]], params[:birth]), { include_blank: "指定なし" } %>
+  <%= form.select :birth, options_for_select([["古い順（年齢が高い）", "asc"], ["新しい順（年齢が低い）", "desc"]], @param_birth), { include_blank: "指定なし" } %>
 
   <%= form.label :per, "表示件数" %>
-  <%= form.select :per, options_for_select([["10件", 10], ["50件", 50], ["100件", 100]], params[:per]), { include_blank: "指定なし" } %>
+  <%= form.select :per, options_for_select([["10件", 10], ["50件", 50], ["100件", 100]], @param_per), { include_blank: "指定なし" } %>
 
   <%= form.submit "検索" %>
 <% end %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,4 +3,7 @@
 Kaminari.configure do |config|
   # 1ページあたりのデフォルト表示件数を20件に設定
   config.default_per_page = 20
+
+  # 1ページあたりの最大の表示件数を100件に指定
+  config.max_per_page = 100
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -57,6 +57,44 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "GET /users?name=value で名前でLIKE検索ができる" do
+    # full_nameで"三上"が部分一致で取得できるユーザー2名でテストを行う。
+    shigeo = users(:shigeo) # "三上 茂雄"
+    hana = users(:hana) # "三上 葉奈"
+    takeo = users(:takeo) # "三井 威雄"
+
+    # 管理者画面のユーザー一覧ページで検索を行う
+    get admin_users_url, params: { name: "三上" }
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+
+    # 検索後のページに<li>三上 茂雄</li>と<li>三上 葉奈</li>が存在しており、
+    # <li>三井 威雄</li>が存在していないことを確認
+    assert_select "li", shigeo.full_name
+    assert_select "li", hana.full_name
+    assert_not_select "li", takeo.full_name
+  end
+
+  test "GET /users?pref=value で都道府県絞り込みができる" do
+    # 住所の都道府県情報で,"福岡県"で取得できるユーザー1名でテストを行う。
+    shigeo = users(:shigeo) # "福岡県"
+    hana = users(:hana) # "栃木県"
+    takeo = users(:takeo) # "大分県"
+
+    # 管理者画面のユーザー一覧ページで検索を行う
+    get admin_users_url, params: { pref: "福岡県" }
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+
+    # 検索後のページに<li>三上 茂雄</li>が存在しており、
+    # <li>三上 葉奈</li>とli>三井 威雄</li>が存在していないことを確認
+    assert_select "li", shigeo.full_name
+    assert_not_select "li", hana.full_name
+    assert_not_select "li", takeo.full_name
+  end
+
   test "POST /users でユーザーとユーザースキルが1件ずつ増える + 画像を作成できる" do
     # POSTリクエスト送信後にユーザーとユーザースキルが作成されたかどうかを確認する
     # assert_differenceメソッドを使用して、UserモデルとUserSkillモデルのレコード数が1増えることを確認

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -10,6 +10,77 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "GET /users?name=value で名前でLIKE検索ができる" do
+    # full_nameで"三上"が部分一致で取得できるユーザー2名でテストを行う。
+    shigeo = users(:shigeo) # "三上 茂雄"
+    hana = users(:hana) # "三上 葉奈"
+    takeo = users(:takeo) # "三井 威雄"
+
+    # 管理者画面のユーザー一覧ページで検索を行う
+    get users_url, params: { name: "三上" }
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+
+    # 検索後のページに<li>三上 茂雄</li>と<li>三上 葉奈</li>が存在しており、
+    # <li>三井 威雄</li>が存在していないことを確認
+    assert_select "li", shigeo.full_name
+    assert_select "li", hana.full_name
+    assert_not_select "li", takeo.full_name
+  end
+
+  test "GET /users?pref=value で都道府県絞り込みができる" do
+    # 住所の都道府県情報で,"福岡県"で取得できるユーザー1名でテストを行う。
+    shigeo = users(:shigeo) # "福岡県"
+    hana = users(:hana) # "栃木県"
+    takeo = users(:takeo) # "大分県"
+
+    # 管理者画面のユーザー一覧ページで検索を行う
+    get users_url, params: { pref: "福岡県" }
+
+    # レスポンスが200番台であることを確認
+    assert_response :success
+
+    # 検索後のページに<li>三上 茂雄</li>が存在しており、
+    # <li>三上 葉奈</li>とli>三井 威雄</li>が存在していないことを確認
+    assert_select "li", shigeo.full_name
+    assert_not_select "li", hana.full_name
+    assert_not_select "li", takeo.full_name
+  end
+
+  test "GET /users?birth=asc で誕生日が古→新に並ぶ" do
+    # フィクスチャ: hana(一番古い) -> shigeo -> takeo(一番新しい)
+    shigeo = users(:shigeo) # 1924-02-27
+    hana = users(:hana) # 1924-01-17
+    takeo = users(:takeo) # 1925-01-13
+
+    get users_url, params: { birth: "asc" }
+    assert_response :success
+
+    # response => ActionDispatch::TestResponse
+    body = response.parsed_body
+
+    # 各名前の出現位置（インデックス）を比較して順序を確認
+    idx_shigeo = body.index(shigeo.full_name)
+    idx_hana = body.index(hana.full_name)
+    idx_takeo = body.index(takeo.full_name)
+
+    assert idx_hana < idx_shigeo && idx_shigeo < idx_takeo
+  end
+
+  test "GET /users?per=10 で ユーザーが10件だけ描画される" do
+    # 表示させる用のユーザーを11人作成
+    11.times do |i|
+      # バリデーションをスキップして保存したいのでsaveメソッドで
+      User.new(full_name: "テスト#{i}").save(validate: false)
+    end
+
+    get users_url, params: { per: "10" }
+    assert_response :success
+  
+    assert_select "li", count: 10
+  end
+
   test "GET /users/:id でユーザー詳細ページが表示される" do
     # usersメソッドを使用して、テスト用のユーザーを取得
     user = users(:test_user)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -19,3 +19,43 @@ test_user:
   building: ""
   birth_date: "2020-06-17"
   department_id: 1
+
+# ユーザー検索のテストで使用
+shigeo:
+  full_name: "三上 茂雄"
+  full_name_kana: "ミカミ シゲオ"
+  gender: 0
+  email: "shigeo5850@hricaif.fxw"
+  home_phone: "0921631287"
+  postal_code: "8030183"
+  prefecture: "福岡県"
+  city: "北九州市"
+  town: "小倉南区"
+  address_block: "194"
+  building: "テラス市丸201"
+  birth_date: "1924-02-27"
+
+hana:
+  full_name: "三上 葉奈"
+  full_name_kana: "ミカミ ハナ"
+  gender: 1
+  email: "hana_mikami@brnglahhlq.zx"
+  home_phone: "0289892990"
+  postal_code: "3240402"
+  prefecture: "栃木県"
+  city: "大田原市"
+  address_block: "247"
+  birth_date: "1924-01-17"
+
+takeo:
+  full_name: "三井 威雄"
+  full_name_kana: "ミツイ タケオ"
+  gender: 0
+  email: "takeo_mitsui@wbrk.ic"
+  home_phone: "0974972724"
+  postal_code: "8791135"
+  prefecture: "大分県"
+  city: "宇佐市"
+  address_block: "4318"
+  building: "スイート和気206"
+  birth_date: "1925-01-13"


### PR DESCRIPTION
## イシュー番号
[PD1_SE_PG-124](https://rizapgroup.backlog.jp/view/PD1_SE_PG-124) Ruby on Rails Lesson11 従業員一覧ページで検索・絞り込みをできるようにしたい。

## 関連ドキュメント
<!--
レビュワーや本PRを見る人に向けて、設計書などの関連するドキュメントがあったらリンクを貼ってください
-->
[Rails API method where](https://api.rubyonrails.org/v7.0/classes/ActiveRecord/QueryMethods.html#method-i-where)

## 実装内容
- 検索用のフォームを作成
- 検索条件のクエリーパラメータからモデルを呼ぶ処理をコントローラに追加
- Userモデルに検索用のクエリ発行のメソッドを作成

## 上記実装の理由
- 検索フォームからクエリパラメータの情報を取得してモデルを読んで検索を行うため

## 画面イメージ
| 一般ユーザー画面 | 管理者ユーザー画面 |
|-----------------|--------------------|
| ![一般ユーザー画面](https://github.com/user-attachments/assets/8e9d5ec0-f890-4aa5-93b0-e13d9dfc2906) | ![管理者ユーザー画面](https://github.com/user-attachments/assets/630ddfce-c403-4c77-9acf-306053174853) |


## 確認したこと
- 機能テスト`admin/users_controller.rb`（管理者ユーザーの一覧画面）
![image](https://github.com/user-attachments/assets/eda07fc6-5383-43d3-8fb5-f5d8eafa68de)

- 機能テスト `users_controller.rb`（一般ユーザーの一覧画面）
![image](https://github.com/user-attachments/assets/bab62290-475c-469d-868d-38957b296914)

| 一般ユーザーの従業員一覧動作確認動画 | 管理者ユーザーの従業員一覧動作確認動画 |
|------------------|-----------------|
| <video src="https://github.com/user-attachments/assets/811fd3a4-d90e-4cde-a373-d3192d482cb8" controls width="420"></video> | <video src="https://github.com/user-attachments/assets/5384bf49-c20a-4012-b998-f65867377f57" controls width="420"></video> |


## 影響範囲
管理画面と一般画面のユーザー一覧のみで他の箇所には影響はありません。

## 特にレビューして欲しい部分
テストの網羅性が不足しているような気がします。しかし、どこまでテストに実装するかまだ自分の中で答えが出ていない状態です。