### PR TITLE
PD1_SE_PG-130 管理画面にメールアドレスを入力してログインできるようにした

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,3 +1,14 @@
 class Admin::ApplicationController < ActionController::Base
   layout 'admin/application'
+
+  private
+    # ログイン中のユーザーを取得する。
+    def current_admin
+      @_current_admin ||= Admin.find_by(id: session[:admin_id]) if session[:admin_id]
+    end
+
+    # ログインユーザーが存在しない場合はログイン画面にリダイレクトする
+    def login_check
+      redirect_to new_admin_login_path unless current_admin
+    end
 end

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -1,4 +1,6 @@
 class Admin::DepartmentsController < Admin::ApplicationController
+  before_action :login_check
+
   # 部署一覧ページ
   def index
     @departments = Department.all

--- a/app/controllers/admin/logins_controller.rb
+++ b/app/controllers/admin/logins_controller.rb
@@ -1,0 +1,21 @@
+class Admin::LoginsController < Admin::ApplicationController
+    def new
+      # ログインフォームを表示するのみ
+    end
+
+    def create
+      # メールアドレスで本人確認を行い、ログイン状態にする
+      admin = Admin.find_by(email: params[:email])
+
+      if admin
+        session[:admin_id] = admin.id
+        redirect_to admin_users_path
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      # ログアウトの処理
+    end
+end

--- a/app/controllers/admin/skills_controller.rb
+++ b/app/controllers/admin/skills_controller.rb
@@ -1,4 +1,6 @@
 class Admin::SkillsController < Admin::ApplicationController
+  before_action :login_check
+
   # スキル一覧ページ
   def index
     @skills = Skill.all

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < Admin::ApplicationController
+  before_action :login_check
+
   # ユーザー一覧ページ
   def index
     @users = User.order(:full_name).page params[:page]

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,2 @@
+class Admin < ApplicationRecord
+end

--- a/app/views/admin/logins/new.html.erb
+++ b/app/views/admin/logins/new.html.erb
@@ -1,0 +1,10 @@
+<h1>ログイン</h1>
+
+<%= form_with url: admin_logins_path, method: :post do |form| %>
+  <div>
+    <%= form.label :email, "メールアドレス" %><br>
+    <%= form.email_field :email %>
+  </div>
+
+  <%= form.submit "ログイン" %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    config.session_store :cookie_store, key: '__ssid'
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
 
     # スキルに関するルーティングを定義
     resources :skills
+
+    # ログイン処理に関するルーティングを定義
+    resources :logins, only: [:new, :create, :destroy]
   end
 
   # resourcesの代わりに個別でルーティングを定義する場合

--- a/db/migrate/20250709005720_create_admins.rb
+++ b/db/migrate/20250709005720_create_admins.rb
@@ -1,0 +1,9 @@
+class CreateAdmins < ActiveRecord::Migration[7.0]
+  def change
+    create_table :admins do |t|
+      t.string :email, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_02_022141) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_09_005720) do
+  create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+  end
+
   create_table "departments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## イシュー番号
- open #25 

## 関連ドキュメント
[Railsガイド Action Controller セッション](https://railsguides.jp/v7.0/action_controller_overview.html#%E3%82%BB%E3%83%83%E3%82%B7%E3%83%A7%E3%83%B3)
[Railsガイド セキュリティガイド](https://railsguides.jp/v7.0/security.html)


## 実装内容
- 管理者ログイン情報を管理するためのルーティングを追加
- 管理者ログイン用のログインフォームを作成
- ログインフォーム以外の管理者画面にはログイン済みでないとアクセスできないように設定

## 上記実装の理由
- 管理者用のログイン処理を作成するため。
- 今回はセッションに管理者IDを保存してcookieにセッションIDを保持してログイン状態を維持しています。

## 画面イメージ
- `/admin/logins/new`

| 管理画面のログインフォーム |
|-----------------|
| ![管理画面](https://github.com/user-attachments/assets/b45a9a2a-c94a-459e-a757-283dca02e2cc) |


## 確認したこと
<!-- 例
- チェックリスト
- 動作確認のスクリーンショット（before/after）
- 画面の収録動画（before/after）
- 自動テストの結果

※「動作確認しました」や「ローカルでチェックしました」などのコメントは、レビュワー目線で意味がないのでやめましょう
-->


## 影響範囲
<!--
実装の背景、修正内容、影響範囲などをQAチームに伝わる言葉で記載してください
-->


## 特にレビューして欲しい部分
<!-- 例
単なるリンク遷移にaタグを使わず、jsで行うのはバグの温床になりかねません。
ただ他に解決策が見つからず、PMと相談した上でやむを得ずこの実装にしました。
念入りにQAを行い、動作に問題ないことを確認します。もし他に良い方法があればご指摘ください。
-->


## その他
<!-- その他関連する情報があれば記載してください -->
