### PR TITLE
PD1_SE_PG-143 webページにパンくずリストやメタデータを追加した

### DIFF
--- a/app/views/admin/departments/edit.html.erb
+++ b/app/views/admin/departments/edit.html.erb
@@ -1,3 +1,18 @@
+<% content_for :title, "#{@department.name}の編集 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+    </li>
+    <li>
+      <a href="<%= admin_department_path(@department) %>"><%= "【管理者】#{@department.ame}の詳細" %></a>
+    </li>
+    <li>
+      <a href="<%= edit_admin_department_path(@department) %>"><%= "#{@department.name}の編集" %></a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>部署の編集</h1>
 
 <%= render "form", department: @department %>

--- a/app/views/admin/departments/edit.html.erb
+++ b/app/views/admin/departments/edit.html.erb
@@ -2,13 +2,13 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+      <%= link_to "【管理者】部署一覧", admin_departments_path %>
     </li>
     <li>
-      <a href="<%= admin_department_path(@department) %>"><%= "【管理者】#{@department.ame}の詳細" %></a>
+      <%= link_to "【管理者】#{@department.name}の詳細", admin_department_path(@department) %>
     </li>
     <li>
-      <a href="<%= edit_admin_department_path(@department) %>"><%= "#{@department.name}の編集" %></a>
+      <%= link_to "#{@department.name}の編集", edit_admin_department_path(@department) %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/departments/index.html.erb
+++ b/app/views/admin/departments/index.html.erb
@@ -2,7 +2,7 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+      <%= link_to "【管理者】部署一覧", admin_departments_path %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/departments/index.html.erb
+++ b/app/views/admin/departments/index.html.erb
@@ -1,4 +1,11 @@
-<p style="color: green"><%= notice %></p>
+<% content_for :title, "部署一覧 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+    </li>
+  </ol>
+<% end %>
 
 <h1>部署一覧</h1>
 

--- a/app/views/admin/departments/new.html.erb
+++ b/app/views/admin/departments/new.html.erb
@@ -2,10 +2,10 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+      <%= link_to "【管理者】部署一覧", admin_departments_path %>
     </li>
     <li>
-      <a href="<%= new_admin_department_path %>">新規部署の作成</a>
+      <%= link_to "新規部署の作成", new_admin_department_path %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/departments/new.html.erb
+++ b/app/views/admin/departments/new.html.erb
@@ -1,3 +1,15 @@
+<% content_for :title, "新規部署の作成 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+    </li>
+    <li>
+      <a href="<%= new_admin_department_path %>">新規部署の作成</a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>新しい部署の作成しよう</h1>
 
 <%= render "form", department: @department %>

--- a/app/views/admin/departments/show.html.erb
+++ b/app/views/admin/departments/show.html.erb
@@ -2,10 +2,10 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+      <%= link_to "【管理者】部署一覧", admin_departments_path %>
     </li>
     <li>
-      <a href="<%= admin_department_path(@department) %>"><%= "【管理者】#{@department.name}の詳細" %></a>
+      <%= link_to "【管理者】#{@department.name}の詳細", admin_department_path(@department) %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/departments/show.html.erb
+++ b/app/views/admin/departments/show.html.erb
@@ -1,4 +1,14 @@
-<p style="color: green"><%= notice %></p>
+<% content_for :title, "#{@department.name}の詳細 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_departments_path %>">【管理者】部署一覧</a>
+    </li>
+    <li>
+      <a href="<%= admin_department_path(@department) %>"><%= "【管理者】#{@department.name}の詳細" %></a>
+    </li>
+  </ol>
+<% end %>
 
 <h1><%= @department.name %></h1>
 

--- a/app/views/admin/skills/edit.html.erb
+++ b/app/views/admin/skills/edit.html.erb
@@ -2,13 +2,13 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+      <%= link_to "【管理者】スキル一覧", admin_skills_path %>
     </li>
     <li>
-      <a href="<%= admin_skill_path(@skill) %>"><%= "【管理者】 #{@skill.name}の詳細" %></a>
+      <%= link_to "【管理者】 #{@skill.name}の詳細", admin_skill_path(@skill) %>
     </li>
     <li>
-      <a href="<%= edit_admin_skill_path(@skill) %>"><%= "#{@skill.name}の編集" %></a>
+      <%= link_to "#{@skill.name}の編集", edit_admin_skill_path(@skill) %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/skills/edit.html.erb
+++ b/app/views/admin/skills/edit.html.erb
@@ -1,3 +1,18 @@
+<% content_for :title, "#{@skill.name}の編集 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+    </li>
+    <li>
+      <a href="<%= admin_skill_path(@skill) %>"><%= "【管理者】 #{@skill.name}の詳細" %></a>
+    </li>
+    <li>
+      <a href="<%= edit_admin_skill_path(@skill) %>"><%= "#{@skill.name}の編集" %></a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>スキルの編集</h1>
 
 <%= render "form", skill: @skill %>

--- a/app/views/admin/skills/index.html.erb
+++ b/app/views/admin/skills/index.html.erb
@@ -1,3 +1,12 @@
+<% content_for :title, "スキル一覧 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>スキル一覧</h1>
 
 <ul id="skills">

--- a/app/views/admin/skills/index.html.erb
+++ b/app/views/admin/skills/index.html.erb
@@ -2,7 +2,7 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+      <%= link_to "【管理者】スキル一覧", admin_skills_path %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/skills/new.html.erb
+++ b/app/views/admin/skills/new.html.erb
@@ -1,3 +1,15 @@
+<% content_for :title, "新規スキルの作成 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+    </li>
+    <li>
+      <a href="<%= new_admin_skill_path %>">新規スキルの作成</a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>新しいスキルの作成しよう</h1>
 
 <%= render "form", skill: @skill %>

--- a/app/views/admin/skills/new.html.erb
+++ b/app/views/admin/skills/new.html.erb
@@ -2,10 +2,10 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+      <%= link_to "【管理者】スキル一覧", admin_skills_path %>
     </li>
     <li>
-      <a href="<%= new_admin_skill_path %>">新規スキルの作成</a>
+    1<%= link_to "新規スキルの作成", new_admin_skill_path %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/skills/show.html.erb
+++ b/app/views/admin/skills/show.html.erb
@@ -2,10 +2,10 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+      <%= link_to "【管理者】スキル一覧", admin_skills_path %>
     </li>
     <li>
-      <a href="<%= admin_skill_path(@skill) %>"><%= "【管理者】 #{@skill.name}の詳細" %></a>
+      <%= link_to "【管理者】 #{@skill.name}の詳細", admin_skill_path(@skill) %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/skills/show.html.erb
+++ b/app/views/admin/skills/show.html.erb
@@ -1,3 +1,15 @@
+<% content_for :title, "#{@skill.name}の詳細 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_skills_path %>">【管理者】スキル一覧</a>
+    </li>
+    <li>
+      <a href="<%= admin_skill_path(@skill) %>"><%= "【管理者】 #{@skill.name}の詳細" %></a>
+    </li>
+  </ol>
+<% end %>
+
 <h1><%= @skill.name %></h1>
 
 <section>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,3 +1,18 @@
+<% content_for :title, "#{@user.full_name}の編集 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+    </li>
+    <li>
+      <a href="<%= admin_user_path(@user) %>"><%= "#{@user.full_name}の詳細" %></a>
+    </li>
+    <li>
+      <a href="<%= edit_admin_user_path(@user) %>"><%= "#{@user.full_name}の編集" %></a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>ユーザーの編集</h1>
 
 <%= render "form", user: @user %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -5,7 +5,7 @@
       <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
     </li>
     <li>
-      <a href="<%= admin_user_path(@user) %>"><%= "#{@user.full_name}の詳細" %></a>
+      <a href="<%= admin_user_path(@user) %>"><%= "【管理者】#{@user.full_name}の詳細" %></a>
     </li>
     <li>
       <a href="<%= edit_admin_user_path(@user) %>"><%= "#{@user.full_name}の編集" %></a>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -2,13 +2,13 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+      <%= link_to "【管理者】ユーザー一覧", admin_users_path %>
     </li>
     <li>
-      <a href="<%= admin_user_path(@user) %>"><%= "【管理者】#{@user.full_name}の詳細" %></a>
+      <%= link_to "【管理者】#{@user.full_name}の詳細", admin_user_path(@user) %>
     </li>
     <li>
-      <a href="<%= edit_admin_user_path(@user) %>"><%= "#{@user.full_name}の編集" %></a>
+      <%= link_to "#{@user.full_name}の編集", edit_admin_user_path(@user) %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,3 +1,12 @@
+<% content_for :title, "ユーザー一覧 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>ユーザー一覧</h1>
 
 <%= form_with url: "/admin/users", method: :get do |form| %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,7 +2,7 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+      <%= link_to "【管理者】ユーザー一覧", admin_users_path %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,3 +1,15 @@
+<% content_for :title, "新規ユーザーの作成 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+    </li>
+    <li>
+      <a href="<%= new_admin_user_path %>">新規ユーザーの作成</a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>新規ユーザーを作成しよう</h1>
 
 <%= render "form", user: @user %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -2,10 +2,10 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+      <%= link_to "【管理者】ユーザー一覧", admin_users_path %>
     </li>
     <li>
-      <a href="<%= new_admin_user_path %>">新規ユーザーの作成</a>
+      <%= link_to "新規ユーザーの作成", new_admin_user_path %>
     </li>
   </ol>
 <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,3 +1,15 @@
+<% content_for :title, "#{@user.full_name}の詳細 | 管理者 | hello-rails" %>
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+    </li>
+    <li>
+      <a href="<%= admin_user_path(@user) %>"><%= "#{@user.full_name}の詳細" %></a>
+    </li>
+  </ol>
+<% end %>
+
 <h1><%= @user.full_name %></h1>
 
 <section>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -2,10 +2,10 @@
 <% content_for :breadcrumb do %>
   <ol>
     <li>
-      <a href="<%= admin_users_path %>">【管理者】ユーザー一覧</a>
+      <%= link_to "【管理者】ユーザー一覧", admin_users_path %>
     </li>
     <li>
-      <a href="<%= admin_user_path(@user) %>"><%= "#{@user.full_name}の詳細" %></a>
+      <%= link_to "#{@user.full_name}の詳細", admin_user_path(@user) %>
     </li>
   </ol>
 <% end %>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Myapp</title>
+    <title><%= yield :title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -18,6 +18,7 @@
         <%= button_to "ログアウト", admin_login_path, method: :delete %>
       <% end %>
     </header>
+    <%= yield :breadcrumb %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,19 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Myapp</title>
+    <title><%= yield :title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
+    <%= yield :head %>
   </head>
 
   <body>
     <header>
         みなさんこんにちは
     </header>
+    <%= yield :breadcrumb %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,27 @@
+<% content_for :title, "ユーザー一覧 | hello-rails" %>
+<% content_for :head do %>
+  <meta name="description" content="ユーザー一覧ページです。">
+  <meta name="keywords" content="ユーザー一覧, ユーザー検索, hello-rails">
+
+  <meta property="og:title" content="ユーザー一覧 | hello-rails">
+  <meta property="og:type" content="index">
+  <meta property="og:url" content="<%= users_url %>">
+  <meta property="og:description" content="ユーザー一覧ページです"。>
+  <meta property="og:site_name" content="hello-rails">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ユーザー一覧 | hello-rails">
+  <meta name="twitter:description" content="ユーザー一覧ページです">
+<% end %>
+
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= users_path %>">ユーザー一覧</a>
+    </li>
+  </ol>
+<% end %>
+
 <h1>ユーザー一覧</h1>
 
 <%= form_with url: "/users", method: :get do |form| %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,17 +1,39 @@
 <% content_for :title, "ユーザー一覧 | hello-rails" %>
 <% content_for :head do %>
-  <meta name="description" content="ユーザー一覧ページです。">
-  <meta name="keywords" content="ユーザー一覧, ユーザー検索, hello-rails">
+  <%= tag.meta name: "description", content: "ユーザー一覧ページです。" %>
+  <%= tag.meta name: "keywords", content: "ユーザー一覧, ユーザー検索, hello-rails" %>
 
-  <meta property="og:title" content="ユーザー一覧 | hello-rails">
-  <meta property="og:type" content="index">
-  <meta property="og:url" content="<%= users_url %>">
-  <meta property="og:description" content="ユーザー一覧ページです"。>
-  <meta property="og:site_name" content="hello-rails">
+  <%= tag.meta property: "og:title", content: "ユーザー一覧 | hello-rails" %>
+  <%= tag.meta property: "og:type", content: "index" %>
+  <%= tag.meta property: "og:url", content: users_url %>
+  <%= tag.meta property: "og:description", content: "ユーザー一覧ページです" %>
+  <%= tag.meta property: "og:site_name", content: "hello-rails" %>
 
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="ユーザー一覧 | hello-rails">
-  <meta name="twitter:description" content="ユーザー一覧ページです">
+  <%= tag.meta name: "twitter:card", content: "summary_large_image" %>
+  <%= tag.meta name: "twitter:title", content: "ユーザー一覧 | hello-rails" %>
+  <%= tag.meta name: "twitter:description", content: "ユーザー一覧ページです" %>
+
+  <script type="application/ld+json">
+    <%= {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "ユーザー一覧",
+          "item": users_url
+      }]
+    }.to_json.html_safe %>
+  </script>
+
+  <script type="application/ld+json">
+    <%= {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "name": "ユーザー一覧 | hello-rails",
+      "url": users_url,
+    }.to_json.html_safe %>
+  </script>
 <% end %>
 
 <% content_for :breadcrumb do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,19 +1,32 @@
 <% content_for :title, "#{@user.full_name} | hello-rails" %>
 <% content_for :head do %>
-  <meta name="description" content='<%= "#{@user.full_name}の詳細画面です" %>'>
-  <meta name="keywords" content='<%= "#{@user.full_name}の詳細, hello-rails" %>'>
+  <%= tag.meta name: "description", content: "#{@user.full_name}の詳細画面です" %>
+  <%= tag.meta name: "keywords", content: "#{@user.full_name}の詳細, hello-rails" %>
 
-  <meta property="og:title" content='<%= "#{@user.full_name} | hello-rails" %>'>
-  <meta property="og:type" content="profile">
-  <meta property="og:url" content="<%= user_url(@user) %>">
-  <meta property="og:description" content='<%= "#{@user.full_name}の詳細画面です" %>'>
-  <meta property="og:image" content="<%= @user.image.present? ? image_user_url(@user) : '' %>">
-  <meta property="og:site_name" content="hello-rails">
+  <%= tag.meta property: "og:title", content: "#{@user.full_name} | hello-rails" %>
+  <%= tag.meta property: "og:type", content: "profile" %>
+  <%= tag.meta property: "og:url", content: user_url(@user) %>
+  <%= tag.meta property: "og:description", content: "#{@user.full_name}の詳細画面です" %>
+  <%= tag.meta property: "og:image", content: @user.image.present? ? image_user_url(@user) : '' %>
+  <%= tag.meta property: "og:site_name", content: "hello-rails" %>
 
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content='<%= "#{@user.full_name} | hello-rails" %>'>
-  <meta name="twitter:description" content='<%= "#{@user.full_name}の詳細画面です" %>'>
-  <meta name="twitter:image" content="<%= @user.image.present? ? image_user_url(@user) : '' %>">
+  <%= tag.meta name: "twitter:card", content: "summary_large_image" %>
+  <%= tag.meta name: "twitter:title", content: "#{@user.full_name} | hello-rails" %>
+  <%= tag.meta name: "twitter:description", content: "#{@user.full_name}の詳細画面です" %>
+  <%= tag.meta name: "twitter:image", content: @user.image.present? ? image_user_url(@user) : '' %>
+
+  <script type="application/ld+json">
+    <%= {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "url": user_url(@user),
+    "mainEntity": {
+        "@type": "Person",
+        "name": @user.full_name,
+        "url": user_url(@user)
+    }
+    }.to_json.html_safe %>
+  </script>
 <% end %>
 
 <% content_for :breadcrumb do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,32 @@
+<% content_for :title, "#{@user.full_name} | hello-rails" %>
+<% content_for :head do %>
+  <meta name="description" content='<%= "#{@user.full_name}の詳細画面です" %>'>
+  <meta name="keywords" content='<%= "#{@user.full_name}の詳細, hello-rails" %>'>
+
+  <meta property="og:title" content='<%= "#{@user.full_name} | hello-rails" %>'>
+  <meta property="og:type" content="profile">
+  <meta property="og:url" content="<%= user_url(@user) %>">
+  <meta property="og:description" content='<%= "#{@user.full_name}の詳細画面です" %>'>
+  <meta property="og:image" content="<%= @user.image.present? ? image_user_url(@user) : '' %>">
+  <meta property="og:site_name" content="hello-rails">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content='<%= "#{@user.full_name} | hello-rails" %>'>
+  <meta name="twitter:description" content='<%= "#{@user.full_name}の詳細画面です" %>'>
+  <meta name="twitter:image" content="<%= @user.image.present? ? image_user_url(@user) : '' %>">
+<% end %>
+
+<% content_for :breadcrumb do %>
+  <ol>
+    <li>
+      <a href="<%= users_path %>">ユーザー一覧</a>
+    </li>
+    <li>
+      <a href="<%= user_path(@user) %>"><%= @user.full_name %></a>
+    </li>
+  </ol>
+<% end %>
+
 <h1><%= @user.full_name %></h1>
 
 <section>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,4 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: Googlebot
+Disallow: /admin/
+
+Sitemap: http://localhost:3000/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>http://loalhost:3000/users</loc>
+    <lastmod>2025-07-18</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
## イシュー番号
- open #31 

## 関連ドキュメント
[Google はウェブ ランキングにキーワード メタタグを使用しません Google検索セントラル](https://developers.google.com/search/blog/2009/09/google-does-not-use-keywords-meta-tag?hl=ja)
[OGPとは XServer](https://www.xserver.ne.jp/bizhp/open-graph-protocol/#HTML%E3%81%A7%E4%BD%9C%E3%81%A3%E3%81%9F%E3%83%9B%E3%83%BC%E3%83%A0%E3%81%BA%E3%83%BC%E3%82%B8)
[The Open Graph protocol](https://ogp.me/)
[サイトマップの作成と送信 Google 検索セントラル](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap?hl=ja#xml)
[robots.txt の書き方、設定と送信 Google検索セントラル](https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt?hl=ja)


## 実装内容
一般ユーザー画面には、ページのタイトルやdescription、パンくずリストやSNS関連のメタデータを追加。
管理者ユーザーには、titleとパンくずリストのみ追加。
`sitemap.xml`や`robots.txt`を追加。


## 上記実装の理由
SEO対策のため。

## 画面イメージ
- `/admin/users/:id/edit`「管理画面のユーザー編集画面」
<img width="591" height="212" alt="image" src="https://github.com/user-attachments/assets/4b80358f-4b66-4603-bae1-96468fa47bcb" />

- 一般ユーザーのユーザー詳細画面のheadタグの中身
<img width="681" height="222" alt="image" src="https://github.com/user-attachments/assets/10297b9b-6835-4716-8f73-b2532ccf3bdc" />

## 確認したこと
- SNSへの反映の確認方法がわからなかった。

## 影響範囲
全ページにパンくずリストとページタイトルが追加されました。

