### PR TITLE
PD1_SE_PG-147 DBに適切にIndexを設定したい

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,7 +86,7 @@ class User < ApplicationRecord
 
     # 検索用のクエリを発行するメソッドを作成する
     # scopeメソッドを使用してActiveRecord::Relationオブジェクトを返しクエリの構築を行う
-    scope :search_by_full_name, ->(full_name) { where("full_name LIKE ?", "%" + full_name + "%") }
+    scope :search_by_full_name, ->(full_name) { where("full_name LIKE ?", full_name + "%") }
 
     scope :search_by_prefecture, ->(prefecture) { where("prefecture = ?", prefecture) }
 

--- a/db/migrate/20250722082057_change_full_name_index_to_users.rb
+++ b/db/migrate/20250722082057_change_full_name_index_to_users.rb
@@ -1,5 +1,6 @@
 class ChangeFullNameIndexToUsers < ActiveRecord::Migration[7.0]
   def change
     add_index :users, :full_name
+    add_index :users, :birth_date
   end
 end

--- a/db/migrate/20250722082057_change_full_name_index_to_users.rb
+++ b/db/migrate/20250722082057_change_full_name_index_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeFullNameIndexToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :full_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_11_060956) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_22_082057) do
   create_table "admin_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest"
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_11_060956) do
     t.bigint "department_id"
     t.binary "image"
     t.index ["department_id"], name: "index_users_on_department_id"
+    t.index ["full_name"], name: "index_users_on_full_name"
   end
 
   add_foreign_key "user_skills", "skills"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_22_082057) do
     t.date "birth_date"
     t.bigint "department_id"
     t.binary "image"
+    t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["department_id"], name: "index_users_on_department_id"
     t.index ["full_name"], name: "index_users_on_full_name"
   end


### PR DESCRIPTION
## イシュー番号
- open #33 

## 関連ドキュメント
[DBにおけるインデックス設計 Zenn](https://zenn.dev/yuki_tu/articles/c0a11385a33e0c)
達人に学ぶDB設計 徹底指南書 第6章


## 実装内容
- Usersテーブルの`full_name`カラムにインデックスを設定
- ユーザー一覧の名前検索を前方一致に変更

## 上記実装の理由
Usersテーブルは多くのレコードを保持しており、`full_name`カラムは検索条件で使用し、カーディナリティが高いためインデックスを設定した。
またインデックスは前方一致にのみ使用されるため変更。


## 確認したこと
1. インデックスなし・ありでの動作確認
2. DBに設定されている全てのインデックスを確認

- インデックスなしの動作
<img width="1112" height="137" alt="image" src="https://github.com/user-attachments/assets/03105d27-cd74-4de7-bc99-a310a72c0b23" />
<img width="1143" height="499" alt="image" src="https://github.com/user-attachments/assets/6101319a-da5c-4609-b2f0-bcf1066e60ff" />


- インデックスありの動作
<img width="1471" height="139" alt="image" src="https://github.com/user-attachments/assets/c36e87d1-9d63-418b-a500-cf73f75f70be" />
<img width="1461" height="503" alt="image" src="https://github.com/user-attachments/assets/03f8db62-2578-434f-815f-97d266b6f3b2" />

- DBに設定されているインデックス
<img width="1845" height="843" alt="image" src="https://github.com/user-attachments/assets/f37924fa-983e-4027-bbe2-d12716e9db74" />


## 影響範囲
一般ユーザー・管理者のユーザー一覧の名前検索が前方一致になる